### PR TITLE
Cleanup bash dotfiles

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -17,8 +17,18 @@ fi
 # added by travis gem
 [ -f /Users/pierre/.travis/travis.sh ] && source /Users/pierre/.travis/travis.sh
 
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh" # This loads nvm
+function _set_bash_specific_options {
+  if [ "$_is_bash" ]; then
+    # Case-insensitive globbing (used in pathname expansion)
+    shopt -s nocaseglob
+
+    # Append to the Bash history file, rather than overwriting it
+    shopt -s histappend
+
+    # Autocorrect typos in path names when using `cd`
+    shopt -s cdspell
+  fi
+}
 
 function _load_ancilliary_dotfiles {
   # * ~/.path can be used to extend `$PATH`.
@@ -44,24 +54,6 @@ function _load_ancilliary_dotfiles {
     fi
   done
 }
-
-
-function _set_bash_specific_options {
-  if [ "$_is_bash" ]; then
-    # Case-insensitive globbing (used in pathname expansion)
-    shopt -s nocaseglob
-
-    # Append to the Bash history file, rather than overwriting it
-    shopt -s histappend
-
-    # Autocorrect typos in path names when using `cd`
-    shopt -s cdspell
-  fi
-}
-
-# Prefer US English and use UTF-8
-export LC_ALL="en_US.UTF-8"
-export LANG="en_US"
 
 function _ssh_hostname_completion {
   # SSH hostnames based on ~/.ssh/config, ignoring wildcards
@@ -104,10 +96,6 @@ function _tweak_history {
 }
 
 function _vim_ftw {
-  # Set the default editor to be vim
-  # shellcheck disable=SC2155
-  export EDITOR=$(which vim)
-
   if [ "$_is_bash" ]; then
     # Edit commands in $EDITOR by typing `Esc` at the prompt
     set -o vi
@@ -117,23 +105,25 @@ function _vim_ftw {
 function _iterm2_features {
   if [ "$_is_bash" ]; then
     # shellcheck disable=SC1090
+    # FIXME use if [ -f ]
     test -e "${HOME}/.iterm2_shell_integration.bash" && source "${HOME}/.iterm2_shell_integration.bash"
   fi
 }
 
 declare -a funcs=(\
+  _enable_completion \
+  _iterm2_features \
   _load_ancilliary_dotfiles \
   _set_bash_specific_options \
-  _ssh_hostname_completion \
-  _enable_completion \
   _setup_docker_client \
+  _ssh_hostname_completion \
   _tweak_history \
   _vim_ftw \
-  _iterm2_features \
 )
 
 for func in ${funcs[@]}; do
   $func
+  # no need to pollute the namespace with these functions
   unset $func
 done
 

--- a/.bashrc
+++ b/.bashrc
@@ -4,8 +4,6 @@
 # FIXME some things should go in .profile (LANG etc)
 
 if [ -n "$BASH_VERSION" ]; then
-  # this has to be set here, variables declared in .profile aren't inherited
-  # here
   _is_bash=true
 fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -1,6 +1,7 @@
 # Expand variables set in .bash_profile to new terminals when only .bashrc is
 # read. cf http://mywiki.wooledge.org/DotFiles
-set +o histexpand
+
+# FIXME some things should go in .profile (LANG etc)
 
 # Override with local settings
 if [ -f ~/.bashrc_local ]; then

--- a/.bashrc
+++ b/.bashrc
@@ -9,12 +9,14 @@ if [ -n "$BASH_VERSION" ]; then
 fi
 
 # Override with local settings
-if [ -f ~/.bashrc_local ]; then
-  source ~/.bashrc_local
+if [ -f "$HOME/.bashrc_local" ]; then
+  # shellcheck source=./.bashrc_local
+  source "$HOME/.bashrc_local"
 fi
 
 # added by travis gem
-[ -f /Users/pierre/.travis/travis.sh ] && source /Users/pierre/.travis/travis.sh
+# shellcheck disable=SC1090
+[ -f "$HOME/.travis/travis.sh" ] && source "$HOME/.travis/travis.sh"
 
 function _set_bash_specific_options {
   if [ "$_is_bash" ]; then
@@ -120,11 +122,11 @@ declare -a funcs=(\
   _vim_ftw \
 )
 
-for func in ${funcs[@]}; do
+for func in "${funcs[@]}"; do
   $func
   # no need to pollute the namespace with these functions
-  unset $func
+  unset "$func"
 done
 
-unset $funcs
-unset $_is_bash
+unset funcs
+unset _is_bash

--- a/.bashrc
+++ b/.bashrc
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+# ^ Enable SC
+
 # Expand variables set in .bash_profile to new terminals when only .bashrc is
 # read. cf http://mywiki.wooledge.org/DotFiles
 

--- a/.bashrc
+++ b/.bashrc
@@ -18,7 +18,7 @@ fi
 [ -f /Users/pierre/.travis/travis.sh ] && source /Users/pierre/.travis/travis.sh
 
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh" # This loads nvm
 
 function _load_ancilliary_dotfiles {
   # * ~/.path can be used to extend `$PATH`.

--- a/.bashrc
+++ b/.bashrc
@@ -1,8 +1,6 @@
 # Expand variables set in .bash_profile to new terminals when only .bashrc is
 # read. cf http://mywiki.wooledge.org/DotFiles
 
-# FIXME some things should go in .profile (LANG etc)
-
 if [ -n "$BASH_VERSION" ]; then
   _is_bash=true
 fi
@@ -39,10 +37,7 @@ function _load_ancilliary_dotfiles {
   declare -a ancilliary_dotfiles=(\
     .bash_aliases \
     .bash_prompt \
-    .exports \
-    .extra \
-    .functions \
-    .path \
+    .path
   )
 
   for file in "${ancilliary_dotfiles[@]}"; do
@@ -126,3 +121,4 @@ for func in ${funcs[@]}; do
 done
 
 unset $funcs
+unset $_is_bash

--- a/.bashrc
+++ b/.bashrc
@@ -65,7 +65,7 @@ function _ssh_hostname_completion {
 function _enable_completion {
   if [ "$_is_bash" ]; then
     # Add tab completion for many Bash commands
-    if which brew > /dev/null && [ -f "$(brew --prefix)/etc/bash_completion" ]; then
+    if hash brew 2>/dev/null && [ -f "$(brew --prefix)/etc/bash_completion" ]; then
       # shellcheck disable=SC1090
       source "$(brew --prefix)/etc/bash_completion";
     elif [ -f /etc/bash_completion ]; then
@@ -77,7 +77,7 @@ function _enable_completion {
 
 function _setup_docker_client {
   # Set env vars for docker if docker-machine is a valid command
-  if command -v docker-machine &>/dev/null; then
+  if hash docker-machine 2>/dev/null; then
     # Check if the docker daemon is running (See https://github.com/Coaxial/dotfiles/issues/3)
     if docker-machine ip default &>/dev/null; then
       eval "$(docker-machine env default)"

--- a/.bashrc
+++ b/.bashrc
@@ -3,6 +3,12 @@
 
 # FIXME some things should go in .profile (LANG etc)
 
+if [ -n "$BASH_VERSION" ]; then
+  # this has to be set here, variables declared in .profile aren't inherited
+  # here
+  _is_bash=true
+fi
+
 # Override with local settings
 if [ -f ~/.bashrc_local ]; then
   source ~/.bashrc_local

--- a/.bashrc
+++ b/.bashrc
@@ -23,6 +23,9 @@ function _set_bash_specific_options {
 
     # Autocorrect typos in path names when using `cd`
     shopt -s cdspell
+
+    # Show expanded command before executing it
+    shopt -s histverify
   fi
 }
 

--- a/.profile
+++ b/.profile
@@ -12,7 +12,7 @@
 if [ -n "$BASH_VERSION" ]; then
   # include .bashrc if it exists
   if [ -f "$HOME/.bashrc" ]; then
-    . "$HOME/.bashrc"
+    source "$HOME/.bashrc"
   fi
 fi
 

--- a/.profile
+++ b/.profile
@@ -24,17 +24,3 @@ PATH="$HOME/bin:$HOME/.local/bin:$PATH"
 export PATH="$PATH:$HOME/.rvm/bin"
 
 [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
-
-function _load_nvm {
-  # nvm
-  # shellcheck disable=SC2046
-  if  [ -f "$(brew --prefix nvm)/nvm.sh" ] && [[ "$OSTYPE" =~ "darwin" ]]
-  then
-    export NVM_DIR="$HOME/.nvm"
-    # shellcheck disable=SC2046
-    # shellcheck disable=SC1090
-    source "$(brew --prefix nvm)/nvm.sh"
-  fi
-}
-
-_load_nvm

--- a/.profile
+++ b/.profile
@@ -15,6 +15,7 @@
 if [ -n "$BASH_VERSION" ]; then
   # include .bashrc if it exists
   if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck source=./.bashrc
     source "$HOME/.bashrc"
   fi
 fi
@@ -34,7 +35,9 @@ export LANG="en_US"
 # shellcheck disable=SC2155
 export EDITOR="$(which vim)"
 
+# shellcheck disable=SC1090
 [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
 
 export NVM_DIR="$HOME/.nvm"
+# shellcheck disable=SC1090
 [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh" # This loads nvm

--- a/.profile
+++ b/.profile
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+# ^ Enable SC
+
 # ~/.profile: executed by the command interpreter for login shells.
 # This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
 # exists.
@@ -29,7 +32,7 @@ export LANG="en_US"
 
 # Set the default editor to be vim
 # shellcheck disable=SC2155
-export EDITOR=$(which vim)
+export EDITOR="$(which vim)"
 
 [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
 

--- a/.profile
+++ b/.profile
@@ -23,4 +23,15 @@ PATH="$HOME/bin:$HOME/.local/bin:$PATH"
 # PATH variable change.
 export PATH="$PATH:$HOME/.rvm/bin"
 
+# Prefer US English and use UTF-8
+export LC_ALL="en_US.UTF-8"
+export LANG="en_US"
+
+# Set the default editor to be vim
+# shellcheck disable=SC2155
+export EDITOR=$(which vim)
+
 [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh" # This loads nvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,13 @@ script:
   - bash -n bootstrap*.sh
   - bash -n lib/scripts/*.sh
   - bash -n .bash_*
+  - bash -n .bashrc
+  - bash -n .profile
   - shellcheck -x bootstrap*.sh
   - shellcheck -x lib/scripts/*.sh
   - shellcheck -x .bash_*
+  - shellcheck -x .bashrc
+  - shellcheck -x .profile
 
 notifications:
   email: false


### PR DESCRIPTION
- Make dotfiles portable to Linux and GNOME-terminal
- `.profile` only contains env variables, the rest goes into `.bashrc`